### PR TITLE
added being able to skip parsing columns

### DIFF
--- a/jamovi/librdata.pyx
+++ b/jamovi/librdata.pyx
@@ -61,7 +61,8 @@ cdef int _handle_table(const char *name, void *ctx):
 cdef int _handle_column(const char *name, rdata_type_t type, void *data, long count, void *ctx):
     parser = <Parser>ctx
     try:
-        Parser.__handle_column(parser, name, type, data, count)
+        if parser.parse_current_table:
+            Parser.__handle_column(parser, name, type, data, count)
         return rdata_error_t.RDATA_OK
     except Exception as e:
         parser._error = e
@@ -81,7 +82,8 @@ cdef int _handle_column_name(const char *name, int index, void *ctx):
 cdef int _handle_text_value(const char *value, int index, void *ctx):
     parser = <Parser>ctx
     try:
-        Parser.__handle_text_value(parser, value, index)
+        if parser.parse_current_table:
+            Parser.__handle_text_value(parser, value, index)
         return rdata_error_t.RDATA_OK
     except Exception as e:
         parser._error = e
@@ -91,7 +93,8 @@ cdef int _handle_text_value(const char *value, int index, void *ctx):
 cdef int _handle_value_label(const char *value, int index, void *ctx):
     parser = <Parser>ctx
     try:
-        Parser.__handle_value_label(parser, value, index)
+        if parser.parse_current_table:
+            Parser.__handle_value_label(parser, value, index)
         return rdata_error_t.RDATA_OK
     except Exception as e:
         parser._error = e
@@ -104,6 +107,7 @@ cdef class Parser:
     cdef int _fd
     cdef int _row_count
     cdef int _var_count
+    parse_current_table = True
 
     cpdef parse(self, path):
 


### PR DESCRIPTION
simple changes to be able to parse only the table name and column names, so that one can explore the file quickly to see what objects and columns are stored without having to parse the whole file, or later being able to parse only selected objects in the file instead of all of them.

Feel free to reject if you don't like it, I'll maintain this on my side in that case.